### PR TITLE
Making sure the script runs with bash

### DIFF
--- a/loadmonitoring/loadmonitoring.sh
+++ b/loadmonitoring/loadmonitoring.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Ensure the script is running with Bash.
+if [ "$(ps -p $$ -o comm=)" != "bash" ]; then
+    exec /bin/bash "$0" "$@"
+fi
+
 STATUS_DIR="/var/log"
 SERVER_STATUS_DIR="$STATUS_DIR/server-status"
 SCRIPT_DIR="/usr/local/bin"


### PR DESCRIPTION
Adding logic to force running the script with bash and avoid issues when users run the script using "sh", which doesn't support process substitution as used for logging. 